### PR TITLE
Dryrun fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ func main() {
 					} else {
 						if (strings.Contains(line, " E") && (line[:2] == "G0" || line[:2] == "G1")) {
 							if (*verbose) {fmt.Printf("  Before:    %s\n", line)}
-							re := regexp.MustCompile(" E([0-9\\.]+)")
+							re := regexp.MustCompile(" E([-0-9\\.]+)")
 							line = re.ReplaceAllString(line, "");
 							if (*verbose) {fmt.Printf("  After:     %s\n", line)}
 							orphanedFCommand, err := regexp.MatchString("G[0-1] F([0-9]+)[ ]?$", line)

--- a/main.go
+++ b/main.go
@@ -229,7 +229,7 @@ func main() {
 				// dryrun processing
 				// ------------------------------------------------------------------
 				if (*dryrun && len(line) > 1) {
-					if (commandInList(line[:4], heatrelated)) {
+					if (len(line) > 3 && commandInList(line[:4], heatrelated)) {
 						// dryrun action: comment-out M104 and similar heat-related commands
 						line = ";" + line;
 						if (*verbose) {fmt.Printf("  Commented: %s\n", line)}


### PR DESCRIPTION
I ensured lines like "G17" do not cause panic (it was assumed every parsed line has at least 4 characters)
```
panic: runtime error: slice bounds out of range [:4] with length 3
main.main()
	./src/main.go:232 +0x2a65
```
I added support for retraction as commands like this were left unmodified:
Before:
```
  Before:    G1 X76.812 Y84.428 E-.25685
  After:     G1 X76.812 Y84.428 E-.25685
```
Now:
```
  Before:    G1 X76.812 Y84.428 E-.25685
  After:     G1 X76.812 Y84.428
```